### PR TITLE
Make puzzlebox portable and document usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-puzzlebox: puzzlebox.c
-ifeq ($(shell uname),Darwin)
-	/usr/local/opt/gcc/bin/gcc-8 -L/usr/local/lib -I/usr/local/include -O -o $@ $< -lpopt -lm -g -D_GNU_SOURCE
-else
-	cc -O -o $@ $< -lpopt -lm -g -D_GNU_SOURCE
-endif
+CC ?= cc
+CFLAGS ?= -O2 -Wall -Wextra -std=gnu99
+LDFLAGS ?=
+LDLIBS ?= -lm
+TARGET ?= puzzlebox
+
+all: $(TARGET)
+
+$(TARGET): puzzlebox.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
 # Puzzle Box
-Makes OpenSCAD file for a puzzle box
+Makes OpenSCAD code for a cylindrical puzzle box.
 
-Has been tested on linux, you probably need libpopt-dev
+## Building
+### Windows (MSYS2 MinGW64)
+1. Install [MSYS2](https://www.msys2.org/) and open the **MSYS2 MinGW64** shell.
+2. Install the toolchain: `pacman -S --needed mingw-w64-x86_64-gcc make`.
+3. Build the binary: `make CC=gcc`.
 
-As you will see from the Makefile, you will need popt development library.
-You also need gcc supporting _GNU_SOURCE for strdupa() and asprintf()
+### Linux or macOS
+Simply run `make`. You can override the compiler with `make CC=gcc` if you prefer.
 
-And, for the avoidance of doubt, obviously, this is normally built using "make"
+The build produces a single executable named `puzzlebox` (or `puzzlebox.exe` on Windows).
 
-When built, use --help for options, or see https://www.me.uk/puzzlebox
+## Usage
+The program writes the OpenSCAD model to standard output. Redirect it to a file and open the
+resulting `.scad` in OpenSCAD to export an STL.
 
-On macOS, this requires gcc, so "brew install gcc", then should make with no problem.
+```
+./puzzlebox > box.scad
+```
+
+Use `--help` to see all supported parameters and their defaults:
+
+```
+./puzzlebox --help
+```
+
+### Example commands
+* Default box: `./puzzlebox > box.scad`
+* Taller maze with more twists: `./puzzlebox --core-height 80 --maze-complexity 7 > tall_box.scad`
+* Round outer wall with tighter spacing: `./puzzlebox --outer-sides 0 --maze-step 2.5 --core-diameter 14 > round_box.scad`
+
+The executable returns `0` on success and only writes OpenSCAD code to stdout. Any errors or
+debug information are printed to stderr.
 
 (c) Copyright 2019 Adrian Kennard. See LICENSE file (GPL)


### PR DESCRIPTION
## Summary
- replace the popt/err dependencies with portable argument parsing, error handling, and help output
- rely on an internal RNG and send only OpenSCAD to stdout while keeping maze options intact
- simplify the build Makefile and add Windows/MSYS2 build and usage documentation

## Testing
- make


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384bd4082c8326b9bbc1f181869e5d)